### PR TITLE
For #54: created card effects and actions

### DIFF
--- a/src/ProjectNeon/Assets/Cards/Card.cs
+++ b/src/ProjectNeon/Assets/Cards/Card.cs
@@ -1,10 +1,11 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using UnityEngine;
 
 [CreateAssetMenu()]
 public class Card : ScriptableObject
 {
     public Sprite Art;
-    public CardEffect Effect;
+    public List<CardEffect> Effects;
     public string Description;
     public string TypeDescription;
 }

--- a/src/ProjectNeon/Assets/Cards/Effect.cs
+++ b/src/ProjectNeon/Assets/Cards/Effect.cs
@@ -3,4 +3,6 @@
 [CreateAssetMenu()]
 public class EffectAction : ScriptableObject
 {
+    [SerializeField]
+    private ScriptableObject effect;
 }

--- a/src/ProjectNeon/Assets/Cards/Effects.meta
+++ b/src/ProjectNeon/Assets/Cards/Effects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7a381823f8a3fe0469484d6a4bcf976f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Cards/Effects/Actions.meta
+++ b/src/ProjectNeon/Assets/Cards/Effects/Actions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 25c168b32f9077341891c0d660c5fa9f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Cards/Effects/Actions/Buff.asset
+++ b/src/ProjectNeon/Assets/Cards/Effects/Actions/Buff.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7886cd971d98d214dafa06c679eb4e3e, type: 3}
+  m_Name: Buff
+  m_EditorClassIdentifier: 
+  turns: 3

--- a/src/ProjectNeon/Assets/Cards/Effects/Actions/Buff.asset.meta
+++ b/src/ProjectNeon/Assets/Cards/Effects/Actions/Buff.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9234039df29b4ba4a93862023b11e7a6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Cards/Effects/Actions/BuffAction.cs
+++ b/src/ProjectNeon/Assets/Cards/Effects/Actions/BuffAction.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu()]
+public class BuffAction : ScriptableObject
+{
+    [SerializeField]
+    private int turns;
+}

--- a/src/ProjectNeon/Assets/Cards/Effects/Actions/BuffAction.cs.meta
+++ b/src/ProjectNeon/Assets/Cards/Effects/Actions/BuffAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7886cd971d98d214dafa06c679eb4e3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Cards/Effects/Actions/Damage.asset
+++ b/src/ProjectNeon/Assets/Cards/Effects/Actions/Damage.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 16c76a0a88165fb45a91dca41c6ed8a8, type: 3}
+  m_Name: Damage
+  m_EditorClassIdentifier: 
+  quantity: 10

--- a/src/ProjectNeon/Assets/Cards/Effects/Actions/Damage.asset.meta
+++ b/src/ProjectNeon/Assets/Cards/Effects/Actions/Damage.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e0fa0cba034c6ca44a32aa05fee73f62
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Cards/Effects/Actions/DamageAction.cs
+++ b/src/ProjectNeon/Assets/Cards/Effects/Actions/DamageAction.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu()]
+
+/**
+ * @todo #54:30min Create Target element so we can execute each Action on it. Then
+ *  add it to all actions inside Cards/Effects/Actions and complete the actions implementations
+ */
+public class DamageAction : ScriptableObject
+{
+    [SerializeField]
+    private int quantity;
+}

--- a/src/ProjectNeon/Assets/Cards/Effects/Actions/DamageAction.cs.meta
+++ b/src/ProjectNeon/Assets/Cards/Effects/Actions/DamageAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16c76a0a88165fb45a91dca41c6ed8a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Cards/Effects/Actions/Heal.asset
+++ b/src/ProjectNeon/Assets/Cards/Effects/Actions/Heal.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ca69e53731a76d449b6001a0ba392a0c, type: 3}
+  m_Name: Heal
+  m_EditorClassIdentifier: 
+  quantity: 5

--- a/src/ProjectNeon/Assets/Cards/Effects/Actions/Heal.asset.meta
+++ b/src/ProjectNeon/Assets/Cards/Effects/Actions/Heal.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 04dddd5a33b544e42a18efdc49fbd1a7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Cards/Effects/Actions/HealAction.cs
+++ b/src/ProjectNeon/Assets/Cards/Effects/Actions/HealAction.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu()]
+public class HealAction : ScriptableObject
+{
+    [SerializeField]
+    private int quantity;
+}

--- a/src/ProjectNeon/Assets/Cards/Effects/Actions/HealAction.cs.meta
+++ b/src/ProjectNeon/Assets/Cards/Effects/Actions/HealAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca69e53731a76d449b6001a0ba392a0c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Cards/Effects/Buff.asset
+++ b/src/ProjectNeon/Assets/Cards/Effects/Buff.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 0}
+  m_Name: Buff
+  m_EditorClassIdentifier: GameAssembly::EffectAction
+  effect: {fileID: 11400000, guid: 9234039df29b4ba4a93862023b11e7a6, type: 2}

--- a/src/ProjectNeon/Assets/Cards/Effects/Buff.asset.meta
+++ b/src/ProjectNeon/Assets/Cards/Effects/Buff.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 41a5f6ffc0f31934e9f2e2baf1fe5c26
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Cards/Effects/BuffSingle.asset
+++ b/src/ProjectNeon/Assets/Cards/Effects/BuffSingle.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64797890eba0742478a285a37369fd53, type: 3}
+  m_Name: BuffSingle
+  m_EditorClassIdentifier: 
+  Effect: {fileID: 11400000, guid: 41a5f6ffc0f31934e9f2e2baf1fe5c26, type: 2}
+  TargetGroup: 3
+  TargetScope: 0

--- a/src/ProjectNeon/Assets/Cards/Effects/BuffSingle.asset.meta
+++ b/src/ProjectNeon/Assets/Cards/Effects/BuffSingle.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e2e838e3545dd744b503190b0349f72
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Cards/Effects/Damage.asset
+++ b/src/ProjectNeon/Assets/Cards/Effects/Damage.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 0}
+  m_Name: Damage
+  m_EditorClassIdentifier: GameAssembly::EffectAction
+  effect: {fileID: 11400000, guid: e0fa0cba034c6ca44a32aa05fee73f62, type: 2}

--- a/src/ProjectNeon/Assets/Cards/Effects/Damage.asset.meta
+++ b/src/ProjectNeon/Assets/Cards/Effects/Damage.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 00b3efe2d252b644b958fb432b77d12b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Cards/Effects/DamageAll.asset
+++ b/src/ProjectNeon/Assets/Cards/Effects/DamageAll.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64797890eba0742478a285a37369fd53, type: 3}
+  m_Name: DamageAll
+  m_EditorClassIdentifier: 
+  Effect: {fileID: 11400000, guid: 00b3efe2d252b644b958fb432b77d12b, type: 2}
+  TargetGroup: 0
+  TargetScope: 1

--- a/src/ProjectNeon/Assets/Cards/Effects/DamageAll.asset.meta
+++ b/src/ProjectNeon/Assets/Cards/Effects/DamageAll.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a0ad8a426fc59cf43a45e20f97eaf455
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Cards/Effects/DamageSingle.asset
+++ b/src/ProjectNeon/Assets/Cards/Effects/DamageSingle.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64797890eba0742478a285a37369fd53, type: 3}
+  m_Name: DamageSingle
+  m_EditorClassIdentifier: 
+  Effect: {fileID: 11400000, guid: 00b3efe2d252b644b958fb432b77d12b, type: 2}
+  TargetGroup: 0
+  TargetScope: 0

--- a/src/ProjectNeon/Assets/Cards/Effects/DamageSingle.asset.meta
+++ b/src/ProjectNeon/Assets/Cards/Effects/DamageSingle.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 84e0d845a371d7a4c909514b3a4e1be5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Cards/Effects/Heal.asset
+++ b/src/ProjectNeon/Assets/Cards/Effects/Heal.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 0}
+  m_Name: Heal
+  m_EditorClassIdentifier: GameAssembly::EffectAction
+  effect: {fileID: 11400000, guid: 04dddd5a33b544e42a18efdc49fbd1a7, type: 2}

--- a/src/ProjectNeon/Assets/Cards/Effects/Heal.asset.meta
+++ b/src/ProjectNeon/Assets/Cards/Effects/Heal.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ff0150a79640f6941ad4b1d71101aa2e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Cards/Effects/HealSingle.asset
+++ b/src/ProjectNeon/Assets/Cards/Effects/HealSingle.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 64797890eba0742478a285a37369fd53, type: 3}
+  m_Name: HealSingle
+  m_EditorClassIdentifier: 
+  Effect: {fileID: 11400000, guid: ff0150a79640f6941ad4b1d71101aa2e, type: 2}
+  TargetGroup: 1
+  TargetScope: 0

--- a/src/ProjectNeon/Assets/Cards/Effects/HealSingle.asset.meta
+++ b/src/ProjectNeon/Assets/Cards/Effects/HealSingle.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9600fec1a6b800741acb82560b4a9ba4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Cards/Heal.asset
+++ b/src/ProjectNeon/Assets/Cards/Heal.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b41b1118d12e5c48a6e7ed020b96a84, type: 3}
+  m_Name: Heal
+  m_EditorClassIdentifier: 
+  Art: {fileID: 0}
+  Effect: {fileID: 11400000, guid: 9600fec1a6b800741acb82560b4a9ba4, type: 2}
+  Description: Heals a Single Target
+  TypeDescription: 

--- a/src/ProjectNeon/Assets/Cards/Heal.asset.meta
+++ b/src/ProjectNeon/Assets/Cards/Heal.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e2b6d20367329a749939a3e6abe83146
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Closes #54 

- created actions for heal, buff and damage
- created effects for HealSingle, HealAll, DamageSingle and BuffSingle
- due to lack of a Target element (the object to which we will apply the effect), the actual effects scripts were not implemented. Left a puzzle to create the effects the target element and then the effects implementations
