### PR TITLE
For #190: Put enemy cards in resolution zone

### DIFF
--- a/src/ProjectNeon/Assets/Core/EventOrchestrator.cs
+++ b/src/ProjectNeon/Assets/Core/EventOrchestrator.cs
@@ -2,6 +2,10 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
+/**
+ * @todo #190:15min Improve Event Orchestrator documentation. Code is not unsderstandabe by itself, and creating new
+ *  EventOrchestrator instances are difficult becase we have to debug the code to guess what each field does.
+ */
 public class EventOrchestrator : MonoBehaviour
 {
     [SerializeField] private GameEvent OnStepsCompleted;

--- a/src/ProjectNeon/Assets/Core/EventOrchestrator.cs
+++ b/src/ProjectNeon/Assets/Core/EventOrchestrator.cs
@@ -2,10 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
-/**
- * @todo #190:15min Improve Event Orchestrator documentation. Code is not unsderstandabe by itself, and creating new
- *  EventOrchestrator instances are difficult becase we have to debug the code to guess what each field does.
- */
 public class EventOrchestrator : MonoBehaviour
 {
     [SerializeField] private GameEvent OnStepsCompleted;

--- a/src/ProjectNeon/Assets/Data/Cards/Actions.meta
+++ b/src/ProjectNeon/Assets/Data/Cards/Actions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6215ca0d818f5934ba250be9dbab8956
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Data/Cards/CardResolutionZone.asset
+++ b/src/ProjectNeon/Assets/Data/Cards/CardResolutionZone.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f69e4bb15f4d64440946fe14630e5dec, type: 3}
+  m_Name: CardResolutionZone
+  m_EditorClassIdentifier: 
+  moves: []

--- a/src/ProjectNeon/Assets/Data/Cards/CardResolutionZone.asset.meta
+++ b/src/ProjectNeon/Assets/Data/Cards/CardResolutionZone.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 74d2299f8469d0b438fc5c0e3412a61d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Data/Cards/CardResolutionZone.cs
+++ b/src/ProjectNeon/Assets/Data/Cards/CardResolutionZone.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 
 public class CardResolutionZone : ScriptableObject
 {
+    [SerializeField]
     private List<PlayedCard> moves = new List<PlayedCard>();
 
     public void Add(PlayedCard played)

--- a/src/ProjectNeon/Assets/Data/Cards/CardResolutionZone.cs
+++ b/src/ProjectNeon/Assets/Data/Cards/CardResolutionZone.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CardResolutionZone : ScriptableObject
+{
+    private List<PlayedCard> enemyMoves = new List<PlayedCard>();
+
+    public void AddEnemyMove(PlayedCard played)
+    {
+        enemyMoves.Add(played);
+    }
+}

--- a/src/ProjectNeon/Assets/Data/Cards/CardResolutionZone.cs
+++ b/src/ProjectNeon/Assets/Data/Cards/CardResolutionZone.cs
@@ -4,10 +4,10 @@ using UnityEngine;
 
 public class CardResolutionZone : ScriptableObject
 {
-    private List<PlayedCard> enemyMoves = new List<PlayedCard>();
+    private List<PlayedCard> moves = new List<PlayedCard>();
 
-    public void AddEnemyMove(PlayedCard played)
+    public void Add(PlayedCard played)
     {
-        enemyMoves.Add(played);
+        moves.Add(played);
     }
 }

--- a/src/ProjectNeon/Assets/Data/Cards/CardResolutionZone.cs.meta
+++ b/src/ProjectNeon/Assets/Data/Cards/CardResolutionZone.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 64b8fd5c235b25f478a4fd473e31dcb3
+guid: f69e4bb15f4d64440946fe14630e5dec
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/src/ProjectNeon/Assets/Data/Enemies/AI/DumbAI.cs
+++ b/src/ProjectNeon/Assets/Data/Enemies/AI/DumbAI.cs
@@ -23,7 +23,7 @@ public class DumbAI : TurnAI
 
     public override PlayedCard Play()
     {
-        Card chosen = me.GetDeck().GetCards().Random();
+        Card chosen = me.GetDeck().Cards.Random();
 
         Target target = me;
         List<Member> team = new List<Member>();
@@ -46,14 +46,14 @@ public class DumbAI : TurnAI
                 target = team.Random();
                 break;
             case Scope.All:
-                target = new Team(team);
+                target = new Team().Init(team);
                 break;
             case Scope.Self:
                 target = me;
                 break;
         }
 
-        return new PlayedCard(me, target, chosen);
+        return new PlayedCard().Init(me, target, chosen);
     }
 
 }

--- a/src/ProjectNeon/Assets/Features/Battle/Cards/EnemyCardSelection.cs
+++ b/src/ProjectNeon/Assets/Features/Battle/Cards/EnemyCardSelection.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EnemyCardSelection : MonoBehaviour
+{
+    [SerializeField] private CardResolutionZone resolutionZone;
+    [SerializeField] private GameEvent onEnemyTurnsConfirmed;
+
+    private List<Enemy> enemies;
+
+    void ChoseCards()
+    {
+        enemies.ForEach(
+            enemy => resolutionZone.Add(enemy.turn.Play())
+        );
+        onEnemyTurnsConfirmed.Publish();
+    }
+}

--- a/src/ProjectNeon/Assets/Features/Battle/Cards/EnemyCardSelection.cs
+++ b/src/ProjectNeon/Assets/Features/Battle/Cards/EnemyCardSelection.cs
@@ -6,10 +6,16 @@ public class EnemyCardSelection : MonoBehaviour
 {
     [SerializeField] private CardResolutionZone resolutionZone;
     [SerializeField] private GameEvent onEnemyTurnsConfirmed;
+    [SerializeField] private BattleState battle;
 
-    private List<Enemy> enemies;
 
-    void ChoseCards()
+    private List<Enemy> enemies = new List<Enemy>();
+    /**
+     * @todo #190:30min Refactor the relation Member - Enemy. At the moment we can't extract
+     *  enemies from BattleState object because they are all wrapped in Member instances.
+     */
+
+    void ChooseCards()
     {
         enemies.ForEach(
             enemy => resolutionZone.Add(enemy.turn.Play())

--- a/src/ProjectNeon/Assets/Features/Battle/Cards/EnemyCardSelection.cs.meta
+++ b/src/ProjectNeon/Assets/Features/Battle/Cards/EnemyCardSelection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2430c41309d720e44937bb280ea9315f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Features/Battle/Editor/BattleAssetMenu.cs
+++ b/src/ProjectNeon/Assets/Features/Battle/Editor/BattleAssetMenu.cs
@@ -10,6 +10,8 @@ class BattleAssetMenu
     static void CardPlayZones() => Create<CardPlayZones>();
     [MenuItem("Assets/Create/Battle/Enemy Area")]
     static void EnemyArea() => Create<EnemyArea>();
+    [MenuItem("Assets/Create/Battle/Card Resolution Zone")]
+    static void CardResolutionZone() => Create<CardResolutionZone>();
 
     private static void Create<T>() where T : ScriptableObject
     {

--- a/src/ProjectNeon/Assets/Features/Battle/Events/EnemyTurnsConfirmed.asset
+++ b/src/ProjectNeon/Assets/Features/Battle/Events/EnemyTurnsConfirmed.asset
@@ -9,7 +9,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ddebcd66e20b8704c81bfa79697d462e, type: 3}
-  m_Name: EnemyTechPoints
+  m_Script: {fileID: 11500000, guid: 76e5be2cb17faaa44ad65fcbce307bb2, type: 3}
+  m_Name: EnemyTurnsConfirmed
   m_EditorClassIdentifier: 
-  maxAmount: 0

--- a/src/ProjectNeon/Assets/Features/Battle/Events/EnemyTurnsConfirmed.asset.meta
+++ b/src/ProjectNeon/Assets/Features/Battle/Events/EnemyTurnsConfirmed.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1975ba5369676894cb9d408f15c2d8e4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Features/Battle/Events/TurnStarted.asset
+++ b/src/ProjectNeon/Assets/Features/Battle/Events/TurnStarted.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76e5be2cb17faaa44ad65fcbce307bb2, type: 3}
+  m_Name: TurnStarted
+  m_EditorClassIdentifier: 

--- a/src/ProjectNeon/Assets/Features/Battle/Events/TurnStarted.asset.meta
+++ b/src/ProjectNeon/Assets/Features/Battle/Events/TurnStarted.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f2a9dd7e51ba2c642ad8b2147a76929e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Features/Battle/Group.cs.meta
+++ b/src/ProjectNeon/Assets/Features/Battle/Group.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eebb34d798b1fbf4da3f031cc2d4baae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Features/Battle/Setup/SetupEnemies.cs
+++ b/src/ProjectNeon/Assets/Features/Battle/Setup/SetupEnemies.cs
@@ -5,20 +5,10 @@ public class SetupEnemies : MonoBehaviour
     [SerializeField] private EnemyArea enemyArea;
     [SerializeField] private EncounterBuilder encounterBuilder;
     [SerializeField] private GameEvent onEncounterGenerated;
-    [SerializeField] private GameEvent onEnemyTurnsConfirmed;
-    [SerializeField] private CardResolutionZone resolutionZone;
-
+    
     void Start()
     {
         enemyArea.enemies = encounterBuilder.Generate();
         onEncounterGenerated.Publish();
-    }
-
-    void ChoseCards()
-    {
-        enemyArea.enemies.ForEach(
-            enemy => resolutionZone.AddEnemyMove(enemy.turn.Play())
-        );
-        onEnemyTurnsConfirmed.Publish();
     }
 }

--- a/src/ProjectNeon/Assets/Features/Battle/Setup/SetupEnemies.cs
+++ b/src/ProjectNeon/Assets/Features/Battle/Setup/SetupEnemies.cs
@@ -5,10 +5,20 @@ public class SetupEnemies : MonoBehaviour
     [SerializeField] private EnemyArea enemyArea;
     [SerializeField] private EncounterBuilder encounterBuilder;
     [SerializeField] private GameEvent onEncounterGenerated;
+    [SerializeField] private GameEvent onEnemyTurnsConfirmed;
+    [SerializeField] private CardResolutionZone resolutionZone;
 
     void Start()
     {
         enemyArea.enemies = encounterBuilder.Generate();
         onEncounterGenerated.Publish();
+    }
+
+    void ChoseCards()
+    {
+        enemyArea.enemies.ForEach(
+            enemy => resolutionZone.AddEnemyMove(enemy.turn.Play())
+        );
+        onEnemyTurnsConfirmed.Publish();
     }
 }

--- a/src/ProjectNeon/Assets/Scenes/BattleScene.unity
+++ b/src/ProjectNeon/Assets/Scenes/BattleScene.unity
@@ -120,6 +120,49 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &384804171
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 384804173}
+  - component: {fileID: 384804172}
+  m_Layer: 0
+  m_Name: CardResolutionZone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &384804172
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 384804171}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f69e4bb15f4d64440946fe14630e5dec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &384804173
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 384804171}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &575126085
 GameObject:
   m_ObjectHideFlags: 0

--- a/src/ProjectNeon/Assets/Scenes/BattleScene.unity
+++ b/src/ProjectNeon/Assets/Scenes/BattleScene.unity
@@ -120,7 +120,7 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &384804171
+--- !u!1 &419769020
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -128,34 +128,55 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 384804173}
-  - component: {fileID: 384804172}
+  - component: {fileID: 419769023}
+  - component: {fileID: 419769022}
+  - component: {fileID: 419769021}
   m_Layer: 0
-  m_Name: CardResolutionZone
+  m_Name: Battle
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &384804172
+--- !u!114 &419769021
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 384804171}
+  m_GameObject: {fileID: 419769020}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f69e4bb15f4d64440946fe14630e5dec, type: 3}
+  m_Script: {fileID: 11500000, guid: 2430c41309d720e44937bb280ea9315f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &384804173
+  resolutionZone: {fileID: 11400000, guid: 74d2299f8469d0b438fc5c0e3412a61d, type: 2}
+  onEnemyTurnsConfirmed: {fileID: 11400000, guid: 1975ba5369676894cb9d408f15c2d8e4,
+    type: 2}
+--- !u!114 &419769022
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 419769020}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9909e676fe54451ba298490b44a5385d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OnStepsCompleted: {fileID: 11400000, guid: f2a9dd7e51ba2c642ad8b2147a76929e, type: 2}
+  RequiredEvents:
+  - {fileID: 11400000, guid: e851efab25f19ec47ac178129a5ff128, type: 2}
+  _isFinished: 0
+  _finishedEvents: []
+--- !u!4 &419769023
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 384804171}
+  m_GameObject: {fileID: 419769020}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}


### PR DESCRIPTION
Closes #190: Put enemy cards in resolution zone

- Created Card Resolution Zone
- In BattleSetup, added ChoseCards() methods, which puts the cards into resolution zone and triggers onEnemyTurnsConfirmed