### PR TITLE
For #207: Removing TargetScope and TargetGroup from Card

### DIFF
--- a/src/ProjectNeon/Assets/Data/Cards/Actions.meta
+++ b/src/ProjectNeon/Assets/Data/Cards/Actions.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: 02f4300d62d99eb48b32a78852878864
-NativeFormatImporter:
+guid: 6215ca0d818f5934ba250be9dbab8956
+folderAsset: yes
+DefaultImporter:
   externalObjects: {}
-  mainObjectFileID: 11400000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Data/Cards/NoCard.asset
+++ b/src/ProjectNeon/Assets/Data/Cards/NoCard.asset
@@ -12,8 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6b41b1118d12e5c48a6e7ed020b96a84, type: 3}
   m_Name: NoCard
   m_EditorClassIdentifier: 
-  Name: NoCard
-  Art: {fileID: 21300000, guid: 4c6b31fddce7ae14c985cb02985b2502, type: 3}
-  Effect: {fileID: 11400000, guid: 5bc2299ef2b56ae40a4adffd3953cef6, type: 2}
-  Description: This card does nothing.
-  TypeDescription: Nothing
+  art: {fileID: 0}
+  description: 
+  typeDescription: 
+  actions: []

--- a/src/ProjectNeon/Assets/Data/Templates/Card.cs
+++ b/src/ProjectNeon/Assets/Data/Templates/Card.cs
@@ -7,15 +7,10 @@ public class Card : ScriptableObject
     [SerializeField] private string description;
     [SerializeField] private string typeDescription;
     [SerializeField] private CardAction[] actions;
-    [SerializeField] private Scope targetScope;
-    [SerializeField] private Group targetGroup;
 
     public Sprite Art => art;
     public string Description => description;
     public string TypeDescription => typeDescription;
     public CardAction[] Actions => actions.ToArray();
-    
-    // @todo #1:15min Remove TargetScope and Group. Update PlayedCard to take Targets for each Card Action. Update AI to choose targets for each Action
-    public Scope TargetScope => targetScope;
-    public Group TargetGroup => targetGroup;
+
 }

--- a/src/ProjectNeon/Assets/Data/Templates/CardAction.cs
+++ b/src/ProjectNeon/Assets/Data/Templates/CardAction.cs
@@ -14,4 +14,15 @@ public class CardAction : ScriptableObject
             effect => effect.Apply(target)
         );
     }
+
+    public Scope Scope
+    {
+        get { return targetScope; }
+    }
+
+    public Group Group
+    {
+        get { return targetGroup; }
+    }
+
 }

--- a/src/ProjectNeon/Assets/Data/Templates/CardAction.cs
+++ b/src/ProjectNeon/Assets/Data/Templates/CardAction.cs
@@ -15,14 +15,7 @@ public class CardAction : ScriptableObject
         );
     }
 
-    public Scope Scope
-    {
-        get { return targetScope; }
-    }
+    public Scope Scope => targetScope;
 
-    public Group Group
-    {
-        get { return targetGroup; }
-    }
-
+    public Group Group => targetGroup;
 }

--- a/src/ProjectNeon/Assets/Data/Templates/DumbAI.cs
+++ b/src/ProjectNeon/Assets/Data/Templates/DumbAI.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using UnityEngine;
 
 public sealed class DumbAI : TurnAI
 {
@@ -14,10 +15,17 @@ public sealed class DumbAI : TurnAI
     {
         var me = activeEnemy.AsMember();
         var card = activeEnemy.Deck.Cards.Random();
-        var possibleTargets = battleState.GetPossibleEnemyTeamTargets(me, card.Actions[0].Group, card.Actions[0].Scope);
-        var target = possibleTargets.Random();
+        List<Target> targets = new List<Target>();
+        card.Actions.ForEach(
+            action =>
+            {
+                Target[] possibleTargets = battleState.GetPossibleEnemyTeamTargets(me, action.Group, action.Scope);
+                Target target = possibleTargets.Random();
+                targets.Add(target);
+            }
+        );
         
-        return new PlayedCard().Init(me, target, card);
+        return new PlayedCard().Init(me, targets.ToArray(), card)
     }
 
 }

--- a/src/ProjectNeon/Assets/Data/Templates/DumbAI.cs
+++ b/src/ProjectNeon/Assets/Data/Templates/DumbAI.cs
@@ -14,7 +14,7 @@ public sealed class DumbAI : TurnAI
     {
         var me = activeEnemy.AsMember();
         var card = activeEnemy.Deck.Cards.Random();
-        var possibleTargets = battleState.GetPossibleEnemyTeamTargets(me, card.TargetGroup, card.TargetScope);
+        var possibleTargets = battleState.GetPossibleEnemyTeamTargets(me, card.Actions[0].Group, card.Actions[0].Scope);
         var target = possibleTargets.Random();
         
         return new PlayedCard().Init(me, target, card);

--- a/src/ProjectNeon/Assets/Features/Battle/Cards/PlayedCard.cs
+++ b/src/ProjectNeon/Assets/Features/Battle/Cards/PlayedCard.cs
@@ -1,12 +1,29 @@
 ﻿using UnityEngine;
 
+/**
+ * Represents a played card from enemy or player character.
+ */
+ 
 public class PlayedCard : MonoBehaviour
 {
-    private Member performer;
-    private Target target;
+    /**
+     * Card played
+     */
     private Card card;
 
-    public PlayedCard Init(Member performer, Target target, Card card)
+    /**
+     * Member which played the card
+     */
+    private Member performer;
+
+    /**
+     * Each Target targeted by the Card effects in the same order that the effects are stored in Card.
+     * 
+     * @todo #207:30min We need a better solution to link targets to effects.
+     */ 
+    private Target[] target;
+
+    public PlayedCard Init(Member performer, Target[] target, Card card)
     {
         this.performer = performer;
         this.target = target;

--- a/src/ProjectNeon/Assets/Features/Battle/Cards/PlayedCard.cs
+++ b/src/ProjectNeon/Assets/Features/Battle/Cards/PlayedCard.cs
@@ -19,7 +19,10 @@ public class PlayedCard : MonoBehaviour
     /**
      * Each Target targeted by the Card effects in the same order that the effects are stored in Card.
      * 
-     * @todo #207:30min We need a better solution to link targets to effects.
+     * @todo #207:30min We need a better solution to link targets to effects. Currently we rely on the order of
+     *  both arrays: the Nth effect in card.efects will target the Nth element from target[]. This is very dangerous
+     *  because we can't guarantee in which particular order they are being stored or created. We need to find a better
+     *  way to relate Effect with Target
      */ 
     private Target[] target;
 

--- a/src/ProjectNeon/Assets/Features/Battle/Cards/SelectCardTargets.cs
+++ b/src/ProjectNeon/Assets/Features/Battle/Cards/SelectCardTargets.cs
@@ -46,7 +46,7 @@ class SelectCardTargets : MonoBehaviour
         cardPresenter.Set(_selectedCard, () => { });
         uiView.SetActive(true);
 
-        var possibleTargets = battleState.GetPossiblePlayerTargets(_selectedCard.TargetGroup, _selectedCard.TargetScope);
+        var possibleTargets = battleState.GetPossiblePlayerTargets(_selectedCard.Actions[0].Group, _selectedCard.Actions[0].Scope);
         // @todo #1:15min Needs to know who Self is, if this is a Hero card.
         
         // @todo #1:30min Create UI Indicator that can indicate possible selections

--- a/src/ProjectNeon/Assets/Features/Battle/Cards/SelectCardTargets.cs
+++ b/src/ProjectNeon/Assets/Features/Battle/Cards/SelectCardTargets.cs
@@ -47,6 +47,9 @@ class SelectCardTargets : MonoBehaviour
         uiView.SetActive(true);
 
         var possibleTargets = battleState.GetPossiblePlayerTargets(_selectedCard.Actions[0].Group, _selectedCard.Actions[0].Scope);
+        // @todo #207:30min Repeat target selection for all card actions. Currently we re just sorting possible targets for the first
+        //  CardAction, but we need select target for all actions after the first one.
+
         // @todo #1:15min Needs to know who Self is, if this is a Hero card.
         
         // @todo #1:30min Create UI Indicator that can indicate possible selections


### PR DESCRIPTION
Closes #207: Removing TargetScope and TargetGroup from Card

- Removed TargetScope and TargetGroup from Card
- Fixed DumbAI to use Scope and Group from first CardAction instead of Card
- Added accessors to get these values from CardAction
- Changed PLayedCard to work with Target array