### PR TITLE
For #201: Correcting bug which resets adventure on deck builder selec…

### DIFF
--- a/src/ProjectNeon/Assets/CurrentAdventureProgress.cs
+++ b/src/ProjectNeon/Assets/CurrentAdventureProgress.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+public class CurrentAdventureProgress : MonoBehaviour
+{
+    [SerializeField] private AdventureProgress adventure;
+    [SerializeField] private TextMeshProUGUI nextText;
+
+    private void OnEnable()
+    {
+        if (!adventure.HasStageBegun)
+        {
+            adventure.Advance();
+        }
+        nextText.text = adventure.CurrentStageSegment.Name;
+    }
+}

--- a/src/ProjectNeon/Assets/CurrentAdventureProgress.cs.meta
+++ b/src/ProjectNeon/Assets/CurrentAdventureProgress.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43eee102921e08044a6f218615568b9f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Data/Progression/Stage1.asset
+++ b/src/ProjectNeon/Assets/Data/Progression/Stage1.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   - {fileID: 11400000, guid: fdede3b3c64360244909eca3ae4bd280, type: 2}
   - {fileID: 11400000, guid: fdede3b3c64360244909eca3ae4bd280, type: 2}
   - {fileID: 11400000, guid: fdede3b3c64360244909eca3ae4bd280, type: 2}
+  - {fileID: 11400000, guid: a73412578a116ed4cb603a8d53a22f94, type: 2}
   - {fileID: 11400000, guid: 16c3bbf7f173e7b45aabc249578f0b7a, type: 2}

--- a/src/ProjectNeon/Assets/Data/Templates/Card.cs
+++ b/src/ProjectNeon/Assets/Data/Templates/Card.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using UnityEngine;
 
 public class Card : ScriptableObject
@@ -12,7 +13,7 @@ public class Card : ScriptableObject
     public Sprite Art => art;
     public string Description => description;
     public string TypeDescription => typeDescription;
-    public CardAction[] Actions => actions.ToArray();
+    public CardAction[] Actions => (actions ?? Array.Empty<CardAction>()).ToArray();
     public Maybe<string> LimitedToClass => new Maybe<string>(onlyPlayableByClass.Value.Length > 0 ? onlyPlayableByClass.Value : null);
 
 }

--- a/src/ProjectNeon/Assets/Features/GameProgression/CurrentAdventureProgress.prefab
+++ b/src/ProjectNeon/Assets/Features/GameProgression/CurrentAdventureProgress.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8048713966522058670
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 663504378442258435}
+  - component: {fileID: 5161425428350466904}
+  m_Layer: 0
+  m_Name: CurrentAdventureProgress
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &663504378442258435
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8048713966522058670}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 344.37097, y: -115.52602, z: -161.58766}
+  m_LocalScale: {x: 3.713733, y: 3.713733, z: 3.713733}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5161425428350466904
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8048713966522058670}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 43eee102921e08044a6f218615568b9f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  current: {fileID: 11400000, guid: e9d87bb76e42a2e46859ea635cdf5bd5, type: 2}

--- a/src/ProjectNeon/Assets/Features/GameProgression/CurrentAdventureProgress.prefab.meta
+++ b/src/ProjectNeon/Assets/Features/GameProgression/CurrentAdventureProgress.prefab.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 31fb75c0f8c1a3e4588827dbcd1e0cf0
-DefaultImporter:
+guid: 5aac50eae323b7341aad266f47580498
+PrefabImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/src/ProjectNeon/Assets/Features/GameProgression/SelectNextStageSegment.cs
+++ b/src/ProjectNeon/Assets/Features/GameProgression/SelectNextStageSegment.cs
@@ -5,26 +5,19 @@ public class SelectNextStageSegment : MonoBehaviour
 {
     [SerializeField] private AdventureProgress adventure;
     [SerializeField] private Navigator navigator;
-    [SerializeField] private TextMeshProUGUI nextText;
 
-    [ReadOnly] [SerializeField] private StageSegment next;
-
-    private void OnEnable()
+    public void Advance()
     {
         if (adventure.IsFinalStageSegment)
             navigator.NavigateToVictoryScene();
         else
-            Advance();
-    }
-
-    private void Advance()
-    {
-        next = adventure.Advance();
-        nextText.text = next.Name;
+        {
+            adventure.Advance();
+        }
     }
 
     public void StartNextStageSegment()
     {
-        next.Start();
+        adventure.CurrentStageSegment.Start();
     }
 }

--- a/src/ProjectNeon/Assets/Features/GameProgression/SelectNextStageSegment.prefab
+++ b/src/ProjectNeon/Assets/Features/GameProgression/SelectNextStageSegment.prefab
@@ -1,0 +1,49 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7909567684708130359
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7274622521359193064}
+  - component: {fileID: 3660919412839632071}
+  m_Layer: 0
+  m_Name: SelectNextStageSegment
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7274622521359193064
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7909567684708130359}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 149.06439, y: 166.63171, z: -99.36113}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3660919412839632071
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7909567684708130359}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe399b055637ca145bae7429a1fef5ad, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  adventure: {fileID: 11400000, guid: e9d87bb76e42a2e46859ea635cdf5bd5, type: 2}
+  navigator: {fileID: 5679756987421974944, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+    type: 3}
+  next: {fileID: 0}

--- a/src/ProjectNeon/Assets/Features/GameProgression/SelectNextStageSegment.prefab.meta
+++ b/src/ProjectNeon/Assets/Features/GameProgression/SelectNextStageSegment.prefab.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 31fb75c0f8c1a3e4588827dbcd1e0cf0
-DefaultImporter:
+guid: 2146e54489ea6df4a86b1e3eed69cc79
+PrefabImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/src/ProjectNeon/Assets/Prefabs/GameNavigator.prefab
+++ b/src/ProjectNeon/Assets/Prefabs/GameNavigator.prefab
@@ -1,0 +1,45 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5679756987421974945
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5679756987421974947}
+  - component: {fileID: 5679756987421974944}
+  m_Layer: 0
+  m_Name: GameNavigator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5679756987421974947
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5679756987421974945}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 149.06439, y: 166.63171, z: -99.36113}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5679756987421974944
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5679756987421974945}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5916f5953c5b464dbfe21ef52288f37, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/src/ProjectNeon/Assets/Prefabs/GameNavigator.prefab.meta
+++ b/src/ProjectNeon/Assets/Prefabs/GameNavigator.prefab.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 31fb75c0f8c1a3e4588827dbcd1e0cf0
-DefaultImporter:
+guid: 6c064e8f34aa22b48832ae3fd4dfadcb
+PrefabImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/src/ProjectNeon/Assets/Scenes/BattleScene.unity
+++ b/src/ProjectNeon/Assets/Scenes/BattleScene.unity
@@ -200,6 +200,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   enemy: []
+--- !u!114 &1201620221 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5679756987421974944, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+    type: 3}
+  m_PrefabInstance: {fileID: 5679756988436391261}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5916f5953c5b464dbfe21ef52288f37, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1428028583
 GameObject:
   m_ObjectHideFlags: 0
@@ -416,6 +428,75 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b4f785b10d268884981b91cca11d3fbf, type: 3}
+--- !u!1001 &5679756988436391261
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5679756987421974945, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_Name
+      value: GameNavigator
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 149.06439
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 166.63171
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -99.36113
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6c064e8f34aa22b48832ae3fd4dfadcb, type: 3}
 --- !u!1001 &5797275367019953378
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -673,8 +754,113 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 55f03c186407e164889ff8ffb62ced78,
         type: 2}
+    - target: {fileID: 2694494873812903186, guid: aec58591a61d9ac48b3f90677a8256b4,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2694494873812903186, guid: aec58591a61d9ac48b3f90677a8256b4,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2694494873812903186, guid: aec58591a61d9ac48b3f90677a8256b4,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2694494873812903186, guid: aec58591a61d9ac48b3f90677a8256b4,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 3660919412839632071, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+    - target: {fileID: 2694494873812903186, guid: aec58591a61d9ac48b3f90677a8256b4,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: Advance
+      objectReference: {fileID: 0}
+    - target: {fileID: 2694494873812903186, guid: aec58591a61d9ac48b3f90677a8256b4,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: aec58591a61d9ac48b3f90677a8256b4, type: 3}
+--- !u!1001 &6532393592247106567
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7909567684708130359, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_Name
+      value: SelectNextStageSegment
+      objectReference: {fileID: 0}
+    - target: {fileID: 3660919412839632071, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: navigator
+      value: 
+      objectReference: {fileID: 1201620221}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 149.06439
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 166.63171
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -99.36113
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2146e54489ea6df4a86b1e3eed69cc79, type: 3}
 --- !u!1001 &7767902492509416076
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/src/ProjectNeon/Assets/Scenes/DeckBuilderScene.unity
+++ b/src/ProjectNeon/Assets/Scenes/DeckBuilderScene.unity
@@ -361,49 +361,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 111251574}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &132488621
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 132488623}
-  - component: {fileID: 132488622}
-  m_Layer: 0
-  m_Name: GameNavigator
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &132488622
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 132488621}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d5916f5953c5b464dbfe21ef52288f37, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &132488623
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 132488621}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 214.10764, y: 204.1355, z: -81.7978}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &449324878
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1502,6 +1459,156 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1607361175}
   m_CullTransparentMesh: 0
+--- !u!1001 &1651550343
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7909567684708130359, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_Name
+      value: SelectNextStageSegment
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 149.06439
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 166.63171
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -99.36113
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2146e54489ea6df4a86b1e3eed69cc79, type: 3}
+--- !u!1001 &1745783218
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5679756987421974945, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_Name
+      value: GameNavigator
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 149.06439
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 166.63171
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -99.36113
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5679756987421974947, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6c064e8f34aa22b48832ae3fd4dfadcb, type: 3}
+--- !u!114 &1745783219 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5679756987421974944, guid: 6c064e8f34aa22b48832ae3fd4dfadcb,
+    type: 3}
+  m_PrefabInstance: {fileID: 1745783218}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5916f5953c5b464dbfe21ef52288f37, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1934720507
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1604,15 +1711,35 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 9195924922475019243, guid: 0d94034e8ba2b4c478eb50c79a239265,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 124.1001
-      objectReference: {fileID: 0}
     - target: {fileID: 6702994911028617721, guid: 0d94034e8ba2b4c478eb50c79a239265,
         type: 3}
       propertyPath: m_Name
       value: DeckBuilderUI
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614590528640295337, guid: 0d94034e8ba2b4c478eb50c79a239265,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -44
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614590528640295337, guid: 0d94034e8ba2b4c478eb50c79a239265,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: -378.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614590528640295337, guid: 0d94034e8ba2b4c478eb50c79a239265,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -814.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4614590528640295337, guid: 0d94034e8ba2b4c478eb50c79a239265,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -194.1001
+      objectReference: {fileID: 0}
+    - target: {fileID: 9195924922475019243, guid: 0d94034e8ba2b4c478eb50c79a239265,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 124.1001
       objectReference: {fileID: 0}
     - target: {fileID: 4682651051099683026, guid: 0d94034e8ba2b4c478eb50c79a239265,
         type: 3}
@@ -2004,26 +2131,6 @@ PrefabInstance:
       propertyPath: m_textInfo.pageCount
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4614590528640295337, guid: 0d94034e8ba2b4c478eb50c79a239265,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -44
-      objectReference: {fileID: 0}
-    - target: {fileID: 4614590528640295337, guid: 0d94034e8ba2b4c478eb50c79a239265,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: -378.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 4614590528640295337, guid: 0d94034e8ba2b4c478eb50c79a239265,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: -814.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 4614590528640295337, guid: 0d94034e8ba2b4c478eb50c79a239265,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -194.1001
-      objectReference: {fileID: 0}
     - target: {fileID: 6702994911331196262, guid: 0d94034e8ba2b4c478eb50c79a239265,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
@@ -2043,7 +2150,7 @@ PrefabInstance:
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 132488622}
+      objectReference: {fileID: 1745783219}
     - target: {fileID: 6702994911331196262, guid: 0d94034e8ba2b4c478eb50c79a239265,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName

--- a/src/ProjectNeon/Assets/Scenes/GameScene.unity
+++ b/src/ProjectNeon/Assets/Scenes/GameScene.unity
@@ -456,5 +456,28 @@ PrefabInstance:
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_StringArgument
       value: DeckBuilder
       objectReference: {fileID: 0}
+    - target: {fileID: 6423351827600901662, guid: 0ef271854911b7a4a8a38f019143d027,
+        type: 3}
+      propertyPath: adventure
+      value: 
+      objectReference: {fileID: 11400000, guid: e9d87bb76e42a2e46859ea635cdf5bd5,
+        type: 2}
+    - target: {fileID: 6423351827600901662, guid: 0ef271854911b7a4a8a38f019143d027,
+        type: 3}
+      propertyPath: nextText
+      value: 
+      objectReference: {fileID: 5349667204731192592}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0ef271854911b7a4a8a38f019143d027, type: 3}
+--- !u!114 &5349667204731192592 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5724702111800043388, guid: 0ef271854911b7a4a8a38f019143d027,
+    type: 3}
+  m_PrefabInstance: {fileID: 5349667204731192591}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/src/ProjectNeon/Assets/Scenes/ShopScene.unity
+++ b/src/ProjectNeon/Assets/Scenes/ShopScene.unity
@@ -120,6 +120,87 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &483665487
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7909567684708130359, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_Name
+      value: SelectNextStageSegment
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 149.06439
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 166.63171
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -99.36113
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7274622521359193064, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2146e54489ea6df4a86b1e3eed69cc79, type: 3}
+--- !u!114 &483665488 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3660919412839632071, guid: 2146e54489ea6df4a86b1e3eed69cc79,
+    type: 3}
+  m_PrefabInstance: {fileID: 483665487}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe399b055637ca145bae7429a1fef5ad, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &959693705
 GameObject:
   m_ObjectHideFlags: 0
@@ -385,6 +466,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Pivot.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1261775261503723933, guid: 27cbd21ef3523dd4f915dcfc05fce4e2,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1261775261503723933, guid: 27cbd21ef3523dd4f915dcfc05fce4e2,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1261775261503723933, guid: 27cbd21ef3523dd4f915dcfc05fce4e2,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1261775261503723933, guid: 27cbd21ef3523dd4f915dcfc05fce4e2,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 483665488}
+    - target: {fileID: 1261775261503723933, guid: 27cbd21ef3523dd4f915dcfc05fce4e2,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: Advance
+      objectReference: {fileID: 0}
+    - target: {fileID: 1261775261503723933, guid: 27cbd21ef3523dd4f915dcfc05fce4e2,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 27cbd21ef3523dd4f915dcfc05fce4e2, type: 3}

--- a/src/ProjectNeon/Assets/State/AdventureProgress.asset
+++ b/src/ProjectNeon/Assets/State/AdventureProgress.asset
@@ -13,5 +13,5 @@ MonoBehaviour:
   m_Name: AdventureProgress
   m_EditorClassIdentifier: 
   currentAdventure: {fileID: 11400000, guid: a7f5f867aa1138b42b2998eaf2e984cc, type: 2}
-  currentStageIndex: 0
-  currentStageSegmentIndex: 0
+  currentStageIndex: -1
+  currentStageSegmentIndex: -1

--- a/src/ProjectNeon/Assets/State/Templates/AdventureProgress.cs
+++ b/src/ProjectNeon/Assets/State/Templates/AdventureProgress.cs
@@ -11,8 +11,9 @@ class AdventureProgress : ScriptableObject
     public bool IsFinalStageSegment => IsFinalStage && currentStageSegmentIndex == CurrentStage.Segments.Length - 1;
     public Stage CurrentStage => currentAdventure.Stages[currentStageIndex];
     public StageSegment CurrentStageSegment => CurrentStage.Segments[currentStageSegmentIndex];
+    public bool HasStageBegun => currentStageSegmentIndex > -1;
 
-    private bool HasBegun => currentStageIndex > -1;
+    private bool HasBegun => currentStageIndex > -1;    
     private bool CurrentStageIsFinished => HasBegun && currentStageSegmentIndex == CurrentStage.Segments.Length - 1;
 
     public void Reset()
@@ -27,7 +28,10 @@ class AdventureProgress : ScriptableObject
     public StageSegment Advance()
     {
         if (!HasBegun || CurrentStageIsFinished)
+        {
             AdvanceStage();
+        }
+            
 
         currentStageSegmentIndex++;
         return CurrentStageSegment;

--- a/src/ProjectNeon/Assets/UI/Menus/GameSceneUI.prefab
+++ b/src/ProjectNeon/Assets/UI/Menus/GameSceneUI.prefab
@@ -36,6 +36,7 @@ RectTransform:
   - {fileID: 7301549057955550328}
   - {fileID: 2840893817491709050}
   - {fileID: 4606419481468447481}
+  - {fileID: 1706997126657664325}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -287,6 +288,81 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 210059058509317146}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2199240275031588166
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1673095650091270462}
+    m_Modifications:
+    - target: {fileID: 8048713966522058670, guid: 5aac50eae323b7341aad266f47580498,
+        type: 3}
+      propertyPath: m_Name
+      value: CurrentAdventureProgress
+      objectReference: {fileID: 0}
+    - target: {fileID: 663504378442258435, guid: 5aac50eae323b7341aad266f47580498,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 344.37097
+      objectReference: {fileID: 0}
+    - target: {fileID: 663504378442258435, guid: 5aac50eae323b7341aad266f47580498,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -115.52602
+      objectReference: {fileID: 0}
+    - target: {fileID: 663504378442258435, guid: 5aac50eae323b7341aad266f47580498,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -161.58766
+      objectReference: {fileID: 0}
+    - target: {fileID: 663504378442258435, guid: 5aac50eae323b7341aad266f47580498,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 663504378442258435, guid: 5aac50eae323b7341aad266f47580498,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 663504378442258435, guid: 5aac50eae323b7341aad266f47580498,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 663504378442258435, guid: 5aac50eae323b7341aad266f47580498,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 663504378442258435, guid: 5aac50eae323b7341aad266f47580498,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 663504378442258435, guid: 5aac50eae323b7341aad266f47580498,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 663504378442258435, guid: 5aac50eae323b7341aad266f47580498,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 663504378442258435, guid: 5aac50eae323b7341aad266f47580498,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5aac50eae323b7341aad266f47580498, type: 3}
+--- !u!4 &1706997126657664325 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 663504378442258435, guid: 5aac50eae323b7341aad266f47580498,
+    type: 3}
+  m_PrefabInstance: {fileID: 2199240275031588166}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2531704805304818797
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -404,36 +480,6 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 5188896434261062195}
-    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: NavigateToDeckBuilderScene
-      objectReference: {fileID: 0}
-    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
     - target: {fileID: 8417788295269649810, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
         type: 3}
       propertyPath: m_textInfo.characterCount
@@ -465,6 +511,36 @@ PrefabInstance:
       value: 'Customize Deck
 
 '
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 5188896434261062195}
+    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: NavigateToDeckBuilderScene
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 15f8bed6dcdfe3944824f5a4606e82a9, type: 3}
@@ -591,41 +667,6 @@ PrefabInstance:
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 4986413871947030710}
-    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: StartNextStageSegment
-      objectReference: {fileID: 0}
-    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
-        type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 137997872680105394, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
-        type: 3}
-      propertyPath: m_Name
-      value: NextText
-      objectReference: {fileID: 0}
     - target: {fileID: 8417788295269649810, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
         type: 3}
       propertyPath: m_textInfo.characterCount
@@ -662,6 +703,41 @@ PrefabInstance:
         type: 3}
       propertyPath: m_firstOverflowCharacterIndex
       value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 137997872680105394, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
+        type: 3}
+      propertyPath: m_Name
+      value: NextText
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 4986413871947030710}
+    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: StartNextStageSegment
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829254996912500189, guid: 15f8bed6dcdfe3944824f5a4606e82a9,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 15f8bed6dcdfe3944824f5a4606e82a9, type: 3}

--- a/src/ProjectNeon/ProjectSettings/EditorBuildSettings.asset
+++ b/src/ProjectNeon/ProjectSettings/EditorBuildSettings.asset
@@ -9,7 +9,7 @@ EditorBuildSettings:
     path: 
     guid: 00000000000000000000000000000000
   - enabled: 1
-    path: Assets/Scenes/TitleScreen.unity
+    path: Assets/TitleScreen.unity
     guid: 821409365c6825c4cbffe6d4bbf13ca9
   - enabled: 1
     path: Assets/Scenes/SquadSelection.unity


### PR DESCRIPTION
Closes #201: Correcting bug which resets adventure on deck builder selection screen

- Created CurrentAdventureProgress, which holds the adventure progress, starts it if the stage has not begun and updates text with stage name and removed these responsibilities from SelectNextStageSegment
- SelectNextStageSegment just advances to next stage segment (and ends it when its done) and start current stage segment
- Added segment advancing script to scenes that advances the game instead game scene
- Added a shop segment in adventure to ease testing