### PR TITLE
For #460: Remove all attack.Target.Members[0] usages from code

### DIFF
--- a/src/ProjectNeon/Assets/Data/Multiple.cs
+++ b/src/ProjectNeon/Assets/Data/Multiple.cs
@@ -1,0 +1,11 @@
+﻿public class Multiple : Target
+{
+    private Member[] _members;
+
+    public Multiple(Member[] members)
+    {
+        _members = members;
+    }
+
+    public Member[] Members => _members;
+}

--- a/src/ProjectNeon/Assets/Data/Multiple.cs.meta
+++ b/src/ProjectNeon/Assets/Data/Multiple.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db710ff99b272bc47b74415341a523c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Data/Templates/Single.cs
+++ b/src/ProjectNeon/Assets/Data/Templates/Single.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+
+public class Single : Target
+{
+    private Member _member;
+
+    public Single(Member member)
+    {
+        _member = member;
+    }
+
+    public Member[] Members => _member.AsArray();
+
+    public override bool Equals(object obj)
+    {
+        return (obj is Single single &&
+               EqualityComparer<Member>.Default.Equals(_member, single._member))
+               ||
+               (obj is Member member &&
+               EqualityComparer<Member>.Default.Equals(_member, member))
+               ;
+    }
+
+    public override int GetHashCode()
+    {
+        return -23316680 + EqualityComparer<Member>.Default.GetHashCode(_member);
+    }
+}

--- a/src/ProjectNeon/Assets/Data/Templates/Single.cs.meta
+++ b/src/ProjectNeon/Assets/Data/Templates/Single.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 906a8ecfa0ca4544a85d477dd19118df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/ProjectNeon/Assets/Data/Templates/Target.cs
+++ b/src/ProjectNeon/Assets/Data/Templates/Target.cs
@@ -1,5 +1,7 @@
 ﻿
 using System;
+using System.Collections.Generic;
+using UnityEngine;
 
 public interface Target  
 {

--- a/src/ProjectNeon/Assets/Features/Effects/Attack.cs
+++ b/src/ProjectNeon/Assets/Features/Effects/Attack.cs
@@ -39,6 +39,6 @@ public sealed class Attack  : Effect
     }
 
     public void Apply(Member source, Member target) {
-        Apply(source, new MemberAsTarget(target));
+        Apply(source, new Single(target));
     }
 }

--- a/src/ProjectNeon/Assets/Features/Effects/EffectOnAttacked.cs
+++ b/src/ProjectNeon/Assets/Features/Effects/EffectOnAttacked.cs
@@ -24,11 +24,7 @@ public class EffectOnAttacked : Effect
 
     void Execute(Attack attack)
     {
-        _effectTarget.Members.ForEach(
-            target => {
-                    if (target.Equals(attack.Target.Members[0]))
-                        _effect.Apply(_performer, _effectTarget);
-                }
-        );
+        if (_effectTarget.Equals(attack.Target))
+            _effect.Apply(_performer, _effectTarget);
     }
 }

--- a/src/ProjectNeon/Assets/Features/Effects/EffectOnAttacker.cs
+++ b/src/ProjectNeon/Assets/Features/Effects/EffectOnAttacker.cs
@@ -25,18 +25,9 @@ public class EffectOnAttacker : Effect
 
     void Execute(Attack attack)
     {
-        _effectTarget.Members.ForEach(
-            target => {
-                /**
-                 * @todo #454:15min Remove all attack.Target.Members[0] usages from code.
-                 */
-                if (target.Equals(attack.Target.Members[0]))
-                {
-                    _effect.Apply(_performer, new MemberAsTarget(attack.Attacker));
-                }
-                    
-            }
-        );
+        if (_effectTarget.Equals(attack.Target))
+            _effect.Apply(_performer, new Single(attack.Attacker));
+
     }
 
 }

--- a/src/ProjectNeon/Assets/Features/Effects/InterceptAttack.cs
+++ b/src/ProjectNeon/Assets/Features/Effects/InterceptAttack.cs
@@ -1,12 +1,12 @@
 ﻿
 using UnityEngine;
 
-class InterceptAttack : Effect
+public class InterceptAttack : Effect
 {
     private Member _performer;
     private Target _effectTarget;
 
-    void Effect.Apply(Member source, Target target)
+    public void Apply(Member source, Target target)
     {
         _performer = source;
         _effectTarget = target;
@@ -15,15 +15,11 @@ class InterceptAttack : Effect
 
     void Execute(Attack attack)
     {
-        _effectTarget.Members.ForEach(
-            target => {
-                if (target.Equals(attack.Target.Members[0]))
-                {
-                    attack.Effect = new NoEffect();
-                    new Attack(attack.Multiplier).Apply(attack.Attacker, _performer);
-                }
-            }
-        );
+        if (_effectTarget.Equals(attack.Target))
+        {
+            attack.Effect = new NoEffect();
+            new Attack(attack.Multiplier).Apply(attack.Attacker, _performer);
+        };
     }
 }
 

--- a/src/ProjectNeon/Assets/Features/Effects/StealLife.cs
+++ b/src/ProjectNeon/Assets/Features/Effects/StealLife.cs
@@ -31,17 +31,12 @@ public class StealLife : Effect
 
     void Execute(Attack attack)
     {
-        _effectTarget.Members.ForEach(
-            target =>
-            {
-                if (target.Equals(attack.Attacker))
-                {
-                    new SimpleEffect(
-                        m => m.GainHp(attack.Multiplier * _ratio)
-                    ).Apply(_performer, new MemberAsTarget(target));
-                }
-            }
-        );
+        if (_effectTarget.Equals(attack.Attacker))
+        {
+            new SimpleEffect(
+                m => m.GainHp(attack.Multiplier * _ratio)
+            ).Apply(_performer, _effectTarget);
+        }
     }
 
 }

--- a/src/ProjectNeon/Assets/Z_Tests/Features/Effects/ArmorFlatTests.cs
+++ b/src/ProjectNeon/Assets/Z_Tests/Features/Effects/ArmorFlatTests.cs
@@ -10,7 +10,7 @@ public sealed class ArmorFlatTests
         var addArmorEffect = ChangeArmorBy(1);
         var target = TestMembers.With(StatType.Armor, 5);
         
-        AllEffects.Apply(addArmorEffect, TestMembers.Any(), new MemberAsTarget(target));
+        AllEffects.Apply(addArmorEffect, TestMembers.Any(), new Single(target));
         
         Assert.AreEqual(6, target.State.Armor());
     }

--- a/src/ProjectNeon/Assets/Z_Tests/Features/Effects/DamageAttackerOnAttackTests.cs
+++ b/src/ProjectNeon/Assets/Z_Tests/Features/Effects/DamageAttackerOnAttackTests.cs
@@ -16,7 +16,7 @@ public sealed class DamageAttackerOnAttackTests
         Member ally = TestMembers.Any();
         Member attacker = TestMembers.Create(s => s.With(StatType.MaxHP, 10).With(StatType.Damagability, 1f));
 
-        AllEffects.Apply(DamageAttackerOnAttack(1), paladin, new MemberAsTarget(ally));
+        AllEffects.Apply(DamageAttackerOnAttack(1), paladin, new Single(ally));
         new Attack(0).Apply(attacker, ally);
 
         Assert.AreEqual(9, attacker.State[TemporalStatType.HP]);
@@ -29,7 +29,7 @@ public sealed class DamageAttackerOnAttackTests
         Member ally = TestMembers.Any();
         Member attacker = TestMembers.Create(s => s.With(StatType.MaxHP, 10).With(StatType.Damagability, 1f));
 
-        AllEffects.Apply(DamageAttackerOnAttack(1), paladin, new MemberAsTarget(ally));
+        AllEffects.Apply(DamageAttackerOnAttack(1), paladin, new Single(ally));
         new Attack(0).Apply(attacker, paladin);
 
         Assert.AreEqual(10, attacker.State[TemporalStatType.HP]);

--- a/src/ProjectNeon/Assets/Z_Tests/Features/Effects/ForNumberOfTurnsTests.cs
+++ b/src/ProjectNeon/Assets/Z_Tests/Features/Effects/ForNumberOfTurnsTests.cs
@@ -17,9 +17,9 @@ public sealed class ForNumberOfTurnsTests
         Member attacker = TestMembers.With(StatType.Attack, 1);
         Member target = TestMembers.Create(s => s.With(StatType.MaxHP, 10).With(StatType.Damagability, 1f));
 
-        timedDamage.Apply(attacker, new MemberAsTarget(target));
+        timedDamage.Apply(attacker, new Single(target));
         timedDamage.AdvanceTurn();
-        timedDamage.Apply(attacker, new MemberAsTarget(target));
+        timedDamage.Apply(attacker, new Single(target));
         
         Assert.AreEqual(
             8, 
@@ -36,9 +36,9 @@ public sealed class ForNumberOfTurnsTests
         Member attacker = TestMembers.With(StatType.Attack, 1);
         Member target = TestMembers.Create(s => s.With(StatType.MaxHP, 10).With(StatType.Damagability, 1f));
 
-        timedDamage.Apply(attacker, new MemberAsTarget(target));
+        timedDamage.Apply(attacker, new Single(target));
         timedDamage.AdvanceTurn();
-        timedDamage.Apply(attacker, new MemberAsTarget(target));
+        timedDamage.Apply(attacker, new Single(target));
 
         Assert.AreEqual(
             9,

--- a/src/ProjectNeon/Assets/Z_Tests/Features/Effects/HealFlatTests.cs
+++ b/src/ProjectNeon/Assets/Z_Tests/Features/Effects/HealFlatTests.cs
@@ -8,7 +8,7 @@ public sealed class HealFlatTests
         var heal5 = new EffectData { EffectType = EffectType.HealFlat, FloatAmount = new FloatReference(5) };
         var target = TestMembers.With(StatType.MaxHP, 10);
         
-        AllEffects.Apply(heal5, TestMembers.Any(), new MemberAsTarget(target));
+        AllEffects.Apply(heal5, TestMembers.Any(), new Single(target));
         
         Assert.AreEqual(10, target.State[TemporalStatType.HP]);
     }
@@ -20,7 +20,7 @@ public sealed class HealFlatTests
         var target = TestMembers.Create(s => s.With(StatType.MaxHP, 10).With(StatType.Damagability, 1f));
         
         target.State.TakeRawDamage(6);
-        AllEffects.Apply(heal5, TestMembers.Any(), new MemberAsTarget(target));
+        AllEffects.Apply(heal5, TestMembers.Any(), new Single(target));
         
         Assert.AreEqual(9, target.State[TemporalStatType.HP]);
     }

--- a/src/ProjectNeon/Assets/Z_Tests/Features/Effects/InterceptAttackTests.cs
+++ b/src/ProjectNeon/Assets/Z_Tests/Features/Effects/InterceptAttackTests.cs
@@ -11,15 +11,7 @@ public sealed class InterceptAttackTests
         Member ally = TestMembers.With(StatType.MaxHP, 10);
         Member attacker = TestMembers.With(StatType.Attack, 1);
 
-        AllEffects.Apply(
-            new EffectData {
-                EffectType = EffectType.InterceptAttackForTurns,
-                NumberOfTurns = new IntReference(1)
-            }, 
-            paladin, 
-            new MemberAsTarget(ally)
-        );
-
+        new InterceptAttack().Apply(paladin, new Single(ally));
         new Attack(5).Apply(attacker, ally);
 
         Assert.AreEqual(

--- a/src/ProjectNeon/Assets/Z_Tests/Features/Effects/PhysicalDamageTests.cs
+++ b/src/ProjectNeon/Assets/Z_Tests/Features/Effects/PhysicalDamageTests.cs
@@ -27,7 +27,7 @@ public sealed class PhysicalDamageTests
             new StatAddends().With(StatType.Armor, 0).With(StatType.MaxHP, 10).With(StatType.Damagability, 1f)
         );
 
-        AllEffects.Apply(data, performer, new MemberAsTarget(target));
+        AllEffects.Apply(data, performer, new Single(target));
         Assert.AreEqual(
             8,
             target.State[TemporalStatType.HP]

--- a/src/ProjectNeon/Assets/Z_Tests/Features/Effects/RecurrentTests.cs
+++ b/src/ProjectNeon/Assets/Z_Tests/Features/Effects/RecurrentTests.cs
@@ -18,8 +18,8 @@ public sealed class RecurrentTests
         Member attacker = TestMembers.With(StatType.Attack, 1);
         Member target = TestMembers.Create(s => s.With(StatType.MaxHP, 10).With(StatType.Damagability, 1f));
 
-        oneTimer.Apply(attacker, new MemberAsTarget(target));
-        oneTimer.Apply(attacker, new MemberAsTarget(target));
+        oneTimer.Apply(attacker, new Single(target));
+        oneTimer.Apply(attacker, new Single(target));
 
         Assert.AreEqual(
             9,

--- a/src/ProjectNeon/Assets/Z_Tests/Features/Effects/ResourceFlat.cs
+++ b/src/ProjectNeon/Assets/Z_Tests/Features/Effects/ResourceFlat.cs
@@ -21,7 +21,7 @@ public sealed class ResourceFlat
     [Test]
     public void ResourceFlat_ApplyEffect()
     {
-        AllEffects.Apply(data, performer, new MemberAsTarget(performer));
+        AllEffects.Apply(data, performer, new Single(performer));
         Assert.AreEqual(
             5,
             performer.State.ResourceTypes[0].MaxAmount

--- a/src/ProjectNeon/Assets/Z_Tests/Features/Effects/ShieldOnAttackedTest.cs
+++ b/src/ProjectNeon/Assets/Z_Tests/Features/Effects/ShieldOnAttackedTest.cs
@@ -16,7 +16,7 @@ public sealed class ShieldAttackedOnAttackTests
         Member ally = TestMembers.With(StatType.Toughness, 10);
         Member attacker = TestMembers.Any();
 
-        AllEffects.Apply(ChangeShieldOnAttackBy(1), paladin, new MemberAsTarget(ally));
+        AllEffects.Apply(ChangeShieldOnAttackBy(1), paladin, new Single(ally));
         new Attack(0).Apply(attacker, ally);
 
         Assert.AreEqual(5, ally.State[TemporalStatType.Shield]);
@@ -29,7 +29,7 @@ public sealed class ShieldAttackedOnAttackTests
         Member ally = TestMembers.With(StatType.Toughness, 10);
         Member attacker = TestMembers.Any();
 
-        AllEffects.Apply(ChangeShieldOnAttackBy(1), paladin, new MemberAsTarget(ally));
+        AllEffects.Apply(ChangeShieldOnAttackBy(1), paladin, new Single(ally));
         new Attack(0).Apply(attacker, paladin);
 
         Assert.AreEqual(0, ally.State[TemporalStatType.Shield]);

--- a/src/ProjectNeon/Assets/Z_Tests/Features/Effects/ShieldToughnessTests.cs
+++ b/src/ProjectNeon/Assets/Z_Tests/Features/Effects/ShieldToughnessTests.cs
@@ -10,7 +10,7 @@ public sealed class ShieldToughnessTests
         var performer = TestMembers.With(StatType.Toughness, 5);
         var target = TestMembers.With(StatType.Toughness, 10);
         
-        AllEffects.Apply(shieldTarget, performer, new MemberAsTarget(target));
+        AllEffects.Apply(shieldTarget, performer, new Single(target));
         Assert.AreEqual(5, target.State[TemporalStatType.Shield]);
     }
 }

--- a/src/ProjectNeon/Assets/Z_Tests/Features/Effects/StealLifeOnAttackTests.cs
+++ b/src/ProjectNeon/Assets/Z_Tests/Features/Effects/StealLifeOnAttackTests.cs
@@ -17,7 +17,7 @@ public sealed class StealLifeOnAttackTests
         Member target = TestMembers.Create(s => s.With(StatType.MaxHP, 10).With(StatType.Damagability, 1f));
         attacker.State.TakeRawDamage(6);
 
-        AllEffects.Apply(StealLifeOnAttack(), caster, new MemberAsTarget(attacker));
+        AllEffects.Apply(StealLifeOnAttack(), caster, new Single(attacker));
         new Attack(5).Apply(attacker, target);
 
         Assert.AreEqual(9, attacker.State[TemporalStatType.HP]);

--- a/src/ProjectNeon/Assets/Z_Tests/Features/Effects/StunTests.cs
+++ b/src/ProjectNeon/Assets/Z_Tests/Features/Effects/StunTests.cs
@@ -8,7 +8,7 @@ public sealed class StunTests
         var stunFor5 = new EffectData { EffectType = EffectType.Stun, NumberOfTurns = new IntReference(5) };
         var target = TestMembers.Any();
 
-        AllEffects.Apply(stunFor5, target, new MemberAsTarget(target));
+        AllEffects.Apply(stunFor5, target, new Single(target));
         Assert.AreEqual(
             5,
             target.State[TemporalStatType.Stun]


### PR DESCRIPTION
Closes #460: Remove all attack.Target.Members[0] usages from code:
- Created `Single` `Target` implementation to deal with target with just one member
- Changed the code to use `Single` instead `MemberAsTarget` in effect context
- Removed `attack.Target.Members[0]`usages